### PR TITLE
chore: replace 'master' with 'main' references

### DIFF
--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -2,9 +2,9 @@ name: Swift
 
 on:
   push:
-    branches: [ master ]
+    branches: [ main ]
   pull_request:
-    branches: [ master ]
+    branches: [ main ]
 
 jobs:
 


### PR DESCRIPTION
> [!WARNING]
> This PR is part of an initiative to change references from 'master' to 'main'.
> 
> **It is highly advised that a human reviews all references before merging. This might not be a full set of changes that are needed.**
> 
> This PR updates references in the `.github` and `argocd` folders.
> 
> ## ✅ No other references for word `master` found.
> 
> More information available at: [Confluence doc](https://mypizza.atlassian.net/wiki/spaces/DEVOPS/pages/6626803725/Branch+rename+from+master+to+main+in+GitHub)
