### PR TITLE
feat: update GH actions to support Node.js 24

### DIFF
--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -11,14 +11,14 @@ jobs:
   lint:
     runs-on: macos-10.15
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v6.0.2
     - name: Lint the code
       run: swiftlint lint
 
   build-xc11_7:
     runs-on: macos-10.15
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v6.0.2
     - name: Select xcode
       run: sudo xcode-select -s /Applications/Xcode_11.7.app
     - name: Generate xcodeproj
@@ -31,7 +31,7 @@ jobs:
   build-xc12:
     runs-on: macos-10.15
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v6.0.2
     - name: Select xcode
       run: sudo xcode-select -s /Applications/Xcode_12.app
     - name: Generate xcodeproj
@@ -44,7 +44,7 @@ jobs:
   build-xc12_2-beta:
     runs-on: macos-10.15
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v6.0.2
     - name: Select xcode
       run: sudo xcode-select -s /Applications/Xcode_12.2.app
     - name: Generate xcodeproj


### PR DESCRIPTION
feat: update GH actions to support Node.js 24

---

## Issue / Motivation

Opened by the [Mass PR workflow](https://github.com/slicelife/github-workflows/actions/workflows/mass-pr.yml). See the short description above for context.

## Changes

See the commit on this PR. The full per-repo run details — counts, the largest diff, and the list of repos that were skipped — are in the **GitHub Actions run summary** of the Mass PR workflow that opened this PR.

## Impact Assessment

- [ ] **High**
- [ ] **Medium**
- [x] **Low**
